### PR TITLE
Blockierende Fehler beheben

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -191,15 +191,17 @@ Kritische Regeln im Überblick:
 Banner erstellen:
 ```bash
 python scripts/create_banner.py \
-  --background hintergrund.png \
   --output banner.png \
   --title1 "Zeile 1" --title2 "Zeile 2" \
   --subtitle "Untertitel" \
   --role "Position @ Unternehmen" \
-  --tags "#GenAI  #EnterpriseAI"
+  --tags "#GenAI  #EnterpriseAI" \
+  --strict
 ```
 
-Das Skript hat Font-Fallback (DejaVuSans wenn NotoSans fehlt) und Gradient-Fallback (wenn kein Hintergrund-Bild vorhanden).
+`--strict` gehört in jeden Aufruf: Ohne die Option meldet das Skript Safe-Zone-Verletzungen nur als Warnung und endet trotzdem mit Exitcode 0, mit der Option endet es mit 1. Ein eigenes Hintergrund-Bild kommt optional über `--background <bild.png>` dazu; fehlt die Option oder der Pfad, entsteht ein Gradient-Hintergrund.
+
+Fehlt NotoSans, greift das Skript auf DejaVuSans zurück. Findet es gar keinen Font mit anwendbarer Größenangabe, sind die gemessenen Textbreiten wertlos; dieser Fall zählt selbst als Verletzung und beendet `--strict` mit 1, statt ein ungeprüftes Banner durchzulassen.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -1117,7 +1117,7 @@ footer .footer-right a:hover { color: var(--text); }
 <!-- ─── Footer ─── -->
 <footer>
   <div class="footer-left">
-    Created by <a href="https://www.linkedin.com/in/markzimmermann/" target="_blank">Mark Zimmermann</a> · 
+    Created by <a href="https://www.linkedin.com/in/mark-zimmermann-5a005123/" target="_blank">Mark Zimmermann</a> · 
     <a href="https://thinkdifferenthinkai.com" target="_blank">Podcast</a> · MIT License
   </div>
   <div class="footer-right">

--- a/references/SCORING.md
+++ b/references/SCORING.md
@@ -40,11 +40,11 @@ Die Gewichtung priorisiert die Faktoren, die den größten Einfluss auf algorith
 
 | Score | Beschreibung | Beispiel |
 |-------|-------------|---------|
-| 0–2 | Nur Jobtitel, keine Keywords, keine Positionierung | „Head of Mobile Development" |
-| 3–4 | Jobtitel + Unternehmen, aber Nische nicht erkennbar | „Head of CoE Mobile at EnBW" |
-| 5–6 | Nische erkennbar, aber zu breit oder generisch | „Digital Innovation & KI @ EnBW" |
-| 7–8 | Klare Nische + Position + 2–3 Keywords + Rolle | „KI im Enterprise \| Head of CoE Mobile @ EnBW \| GenAI, Agents \| Autor" |
-| 9–10 | Perfekt: Nische + Position + Keywords + Rolle + merkbar | „Künstliche Intelligenz in der Energiewende \| Head of CoE Mobile @ EnBW \| GenAI, Agents, Enterprise AI \| Podcast-Host" |
+| 0–2 | Nur Jobtitel, keine Keywords, keine Positionierung | „Head of Digital Platforms" |
+| 3–4 | Jobtitel + Unternehmen, aber Nische nicht erkennbar | „Head of Digital Platforms at Musterwerke AG" |
+| 5–6 | Nische erkennbar, aber zu breit oder generisch | „Digital Innovation & KI @ Musterwerke AG" |
+| 7–8 | Klare Nische + Position + 2–3 Keywords + Rolle | „KI im Enterprise \| Head of Digital Platforms @ Musterwerke AG \| GenAI, Agents \| Autor" |
+| 9–10 | Perfekt: Nische + Position + Keywords + Rolle + merkbar | „Künstliche Intelligenz in der Logistik \| Head of Digital Platforms @ Musterwerke AG \| GenAI, Agents, Enterprise AI \| Podcast-Host" |
 
 ---
 

--- a/references/TEMPLATES.md
+++ b/references/TEMPLATES.md
@@ -20,9 +20,9 @@ Dieses Dokument enthält Templates für alle Deliverables des Optimierungs-Workf
 
 **Beispiel**:
 ```
-Künstliche Intelligenz in der Energiewende | Head of CoE Mobile @ EnBW | GenAI, Agents, Enterprise AI | Podcast-Host
+Künstliche Intelligenz in der Logistik | Head of Digital Platforms @ Musterwerke AG | GenAI, Agents, Enterprise AI | Podcast-Host
 ```
-Zeichenzahl: 119 | Erste 60 Zeichen: „Künstliche Intelligenz in der Energiewende | Head o…"
+Zeichenzahl: 129 | Erste 60 Zeichen: „Künstliche Intelligenz in der Logistik | Head of Digital Pla…"
 
 ### 1.2 Template B: Position-First (für Corporate-Fokus)
 
@@ -32,7 +32,7 @@ Zeichenzahl: 119 | Erste 60 Zeichen: „Künstliche Intelligenz in der Energiewe
 
 **Beispiel**:
 ```
-Head of CoE Mobile @ EnBW | KI-Agenten im Enterprise | GenAI, AI Strategy | Autor von 14+ Fachbüchern
+Head of Digital Platforms @ Musterwerke AG | KI-Agenten im Enterprise | GenAI, AI Strategy | Autor von 6 Fachbüchern
 ```
 
 ### 1.3 Template C: Mission-Statement (für starke persönliche Marke)
@@ -43,7 +43,7 @@ Head of CoE Mobile @ EnBW | KI-Agenten im Enterprise | GenAI, AI Strategy | Auto
 
 **Beispiel**:
 ```
-Ich baue Brücken zwischen KI-Hype und Enterprise-Realität | Head of CoE Mobile @ EnBW | Autor & Podcast-Host
+Ich baue Brücken zwischen KI-Hype und Enterprise-Realität | Head of Digital Platforms @ Musterwerke AG | Autor & Podcast-Host
 ```
 
 ### 1.4 Template D: Autor/Speaker-First (für Personen mit starkem Social Proof)
@@ -54,7 +54,7 @@ Ich baue Brücken zwischen KI-Hype und Enterprise-Realität | Head of CoE Mobile
 
 **Beispiel**:
 ```
-Autor von 14+ KI-Büchern | Head of CoE Mobile @ EnBW | GenAI, Agents, Enterprise AI | heise-Fachautor
+Autor von 6 KI-Büchern | Head of Digital Platforms @ Musterwerke AG | GenAI, Agents, Enterprise AI | Fachmedien-Autor
 ```
 
 ### Headline-Checkliste
@@ -281,7 +281,7 @@ Beachte bei JEDEM Post:
 - Absätze: Max. 3 Zeilen pro Absatz (mobil-optimiert, größerer Bildschirmanteil)
 - Zeilenumbrüche: Großzügig einsetzen (Whitespace = Lesbarkeit = Dwell Time)
 - Hashtags: [3–5 strategische] am Ende des Posts
-- Pflicht-Hashtag: [z.B. #WIRsindEnBW]
+- Pflicht-Hashtag: [z.B. #WIRsindMusterwerke]
 - Emojis: Max. 3, nur als Aufzählungszeichen oder Akzente
 
 ## HOOK-TYPEN (10 Varianten)

--- a/scripts/create_banner.py
+++ b/scripts/create_banner.py
@@ -11,14 +11,17 @@ Verwendung:
         --tags "#GenAI  #EnterpriseAI" \
         [--background background.png] \
         [--book cover.png] \
-        [--accent 0,200,255]
+        [--accent 0,200,255] \
+        [--strict]
 
 Ohne --background wird ein Gradient-Hintergrund erzeugt.
+Mit --strict endet der Aufruf bei Safe-Zone-Verletzungen mit Exitcode 1.
 """
 
 from PIL import Image, ImageDraw, ImageFont, ImageFilter
 import os
 import argparse
+import sys
 
 
 def find_font(name, size):
@@ -89,7 +92,8 @@ def create_linkedin_banner(
         tags_size: Schriftgröße Tags (min. 16)
 
     Returns:
-        Pfad zum gespeicherten Banner
+        Tuple (Pfad zum gespeicherten Banner, Liste der Safe-Zone-Verletzungen).
+        Die Liste ist leer, wenn alle Elemente innerhalb der Safe Zone liegen.
     """
 
     # Validierung Schriftgrößen
@@ -97,6 +101,8 @@ def create_linkedin_banner(
     assert subtitle_size >= 22, f"Untertitel zu klein: {subtitle_size}px (min. 22)"
     assert role_size >= 18, f"Rolle zu klein: {role_size}px (min. 18)"
     assert tags_size >= 16, f"Tags zu klein: {tags_size}px (min. 16)"
+
+    violations = []
 
     # === SETUP ===
     SAFE_X_MIN = 520
@@ -148,7 +154,9 @@ def create_linkedin_banner(
             # Safe-Zone-Check
             bbox = draw.textbbox((TEXT_X, y), line, font=f_title)
             if bbox[2] > SAFE_X_MAX:
-                print(f"⚠️  WARNUNG: Titel '{line}' ragt über Safe Zone (x={bbox[2]})")
+                msg = f"Titel '{line}' ragt über Safe Zone (x={bbox[2]}, max={SAFE_X_MAX})"
+                violations.append(msg)
+                print(f"⚠️  WARNUNG: {msg}")
             y += title_size + 6
 
     # Akzentlinie
@@ -161,7 +169,9 @@ def create_linkedin_banner(
         draw.text((TEXT_X, y), subtitle, fill=(180, 215, 245), font=f_sub)
         bbox = draw.textbbox((TEXT_X, y), subtitle, font=f_sub)
         if bbox[2] > SAFE_X_MAX:
-            print(f"⚠️  WARNUNG: Untertitel ragt über Safe Zone (x={bbox[2]})")
+            msg = f"Untertitel ragt über Safe Zone (x={bbox[2]}, max={SAFE_X_MAX})"
+            violations.append(msg)
+            print(f"⚠️  WARNUNG: {msg}")
         y += subtitle_size + 10
 
     # Rolle
@@ -169,7 +179,9 @@ def create_linkedin_banner(
         draw.text((TEXT_X, y), role, fill=(150, 190, 220), font=f_role)
         bbox = draw.textbbox((TEXT_X, y), role, font=f_role)
         if bbox[2] > SAFE_X_MAX:
-            print(f"⚠️  WARNUNG: Rolle ragt über Safe Zone (x={bbox[2]})")
+            msg = f"Rolle ragt über Safe Zone (x={bbox[2]}, max={SAFE_X_MAX})"
+            violations.append(msg)
+            print(f"⚠️  WARNUNG: {msg}")
         y += role_size + 12
 
     # Tags (KEIN farbiger Hintergrund – nur Textfarbe)
@@ -177,12 +189,16 @@ def create_linkedin_banner(
         draw.text((TEXT_X, y), tags, fill=accent_color, font=f_tags)
         bbox = draw.textbbox((TEXT_X, y), tags, font=f_tags)
         if bbox[2] > SAFE_X_MAX:
-            print(f"⚠️  WARNUNG: Tags ragen über Safe Zone (x={bbox[2]})")
+            msg = f"Tags ragen über Safe Zone (x={bbox[2]}, max={SAFE_X_MAX})"
+            violations.append(msg)
+            print(f"⚠️  WARNUNG: {msg}")
         y += tags_size + 8
 
     # Layout-Überlauf prüfen
     if y > SAFE_Y_MAX:
-        print(f"⚠️  WARNUNG: Content überläuft y-Safe-Zone (y={y}, max={SAFE_Y_MAX})")
+        msg = f"Content überläuft y-Safe-Zone (y={y}, max={SAFE_Y_MAX})"
+        violations.append(msg)
+        print(f"⚠️  WARNUNG: {msg}")
 
     # === BUCH-COVER (optional) ===
     if book_cover_path and os.path.exists(book_cover_path):
@@ -220,8 +236,10 @@ def create_linkedin_banner(
         if bk_x + book_img.width < SAFE_X_MAX:
             base.paste(book_img, (bk_x, bk_y), book_img)
         else:
-            print(f"⚠️  Buch passt nicht in Safe Zone (x_end={bk_x + book_img.width})")
-            print("   → Buch wird weggelassen.")
+            msg = (f"Buchcover passt nicht in Safe Zone "
+                   f"(x_end={bk_x + book_img.width}, max={SAFE_X_MAX}), wird weggelassen")
+            violations.append(msg)
+            print(f"⚠️  {msg}")
 
     # === SPEICHERN ===
     final = base.convert('RGB')
@@ -234,7 +252,7 @@ def create_linkedin_banner(
 
     print(f"✓ Banner gespeichert: {output_path}")
     print(f"  Größe: {final.size}, Datei: {file_size / 1024:.0f} KB")
-    return output_path
+    return output_path, violations
 
 
 if __name__ == "__main__":
@@ -249,10 +267,12 @@ if __name__ == "__main__":
     parser.add_argument("--tags", default="", help="Hashtags")
     parser.add_argument("--book", default=None, help="Pfad zum Buchcover")
     parser.add_argument("--accent", default="0,200,255", help="Akzent-Farbe als R,G,B")
+    parser.add_argument("--strict", action="store_true",
+                        help="Bei Safe-Zone-Verletzungen mit Exitcode 1 enden")
     args = parser.parse_args()
 
     accent = tuple(int(x) for x in args.accent.split(","))
-    create_linkedin_banner(
+    _, violations = create_linkedin_banner(
         background_path=args.background,
         output_path=args.output,
         title_line1=args.title1,
@@ -263,3 +283,9 @@ if __name__ == "__main__":
         book_cover_path=args.book,
         accent_color=accent,
     )
+
+    if violations and args.strict:
+        print(f"\n✗ {len(violations)} Safe-Zone-Verletzung(en):", file=sys.stderr)
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/create_banner.py
+++ b/scripts/create_banner.py
@@ -17,7 +17,6 @@ Verwendung:
 from PIL import Image, ImageDraw, ImageFont, ImageFilter
 import os
 import argparse
-import sys
 
 
 def find_font(name, size):

--- a/scripts/create_banner.py
+++ b/scripts/create_banner.py
@@ -44,9 +44,15 @@ def find_font(name, size):
         if os.path.exists(path):
             print(f"⚠️  Font {name} nicht gefunden, Fallback: {fallback}")
             return ImageFont.truetype(path, size)
-    # Letzter Fallback: PIL Default
-    print(f"⚠️  Kein passender Font gefunden, verwende PIL-Default")
-    return ImageFont.load_default()
+    # Letzter Fallback: PIL Default in der angeforderten Groesse
+    print("⚠️  Kein passender Font gefunden, verwende PIL-Default")
+    try:
+        return ImageFont.load_default(size=size)
+    except TypeError:
+        # Pillow < 10.1 kennt den size-Parameter nicht; dann bleibt nur der
+        # Bitmap-Font in fester Groesse, die Safe-Zone-Pruefung misst dann zu klein.
+        print("⚠️  Pillow ohne size-Parameter, Safe-Zone-Pruefung ist ungenau")
+        return ImageFont.load_default()
 
 
 def create_linkedin_banner(

--- a/scripts/create_banner.py
+++ b/scripts/create_banner.py
@@ -16,6 +16,8 @@ Verwendung:
 
 Ohne --background wird ein Gradient-Hintergrund erzeugt.
 Mit --strict endet der Aufruf bei Safe-Zone-Verletzungen mit Exitcode 1.
+Das gilt auch, wenn kein Font mit anwendbarer Groessenangabe gefunden wird:
+Dann ist die Messung nicht belastbar und zaehlt selbst als Verletzung.
 """
 
 from PIL import Image, ImageDraw, ImageFont, ImageFilter
@@ -25,7 +27,14 @@ import sys
 
 
 def find_font(name, size):
-    """Suche Font mit Fallback auf DejaVuSans."""
+    """Suche Font mit Fallback auf DejaVuSans.
+
+    Returns:
+        Tuple (Font, exakt). exakt ist False, wenn nur ein Font ohne
+        anwendbare Groessenangabe uebrig bleibt. Die Textbreiten stammen
+        dann aus einer anderen Groesse als der angeforderten, die
+        Safe-Zone-Pruefung ist damit nicht belastbar.
+    """
     font_dirs = [
         "/usr/share/fonts/truetype/noto/",
         "/usr/share/fonts/truetype/dejavu/",
@@ -39,23 +48,23 @@ def find_font(name, size):
     for d in font_dirs:
         path = os.path.join(d, name)
         if os.path.exists(path):
-            return ImageFont.truetype(path, size)
+            return ImageFont.truetype(path, size), True
     # Fallback
     fallback = fallback_map.get(name, "DejaVuSans.ttf")
     for d in font_dirs:
         path = os.path.join(d, fallback)
         if os.path.exists(path):
             print(f"⚠️  Font {name} nicht gefunden, Fallback: {fallback}")
-            return ImageFont.truetype(path, size)
+            return ImageFont.truetype(path, size), True
     # Letzter Fallback: PIL Default in der angeforderten Groesse
     print("⚠️  Kein passender Font gefunden, verwende PIL-Default")
     try:
-        return ImageFont.load_default(size=size)
+        return ImageFont.load_default(size=size), True
     except TypeError:
         # Pillow < 10.1 kennt den size-Parameter nicht; dann bleibt nur der
         # Bitmap-Font in fester Groesse, die Safe-Zone-Pruefung misst dann zu klein.
         print("⚠️  Pillow ohne size-Parameter, Safe-Zone-Pruefung ist ungenau")
-        return ImageFont.load_default()
+        return ImageFont.load_default(), False
 
 
 def create_linkedin_banner(
@@ -93,7 +102,9 @@ def create_linkedin_banner(
 
     Returns:
         Tuple (Pfad zum gespeicherten Banner, Liste der Safe-Zone-Verletzungen).
-        Die Liste ist leer, wenn alle Elemente innerhalb der Safe Zone liegen.
+        Die Liste ist leer, wenn alle Elemente innerhalb der Safe Zone liegen und
+        die Messung belastbar ist. Ein Font ohne anwendbare Groessenangabe zaehlt
+        selbst als Verletzung, weil die gemessenen Breiten dann nichts aussagen.
     """
 
     # Validierung Schriftgrößen
@@ -138,10 +149,16 @@ def create_linkedin_banner(
     draw = ImageDraw.Draw(base)
 
     # Fonts mit Fallback
-    f_title = find_font("NotoSans-Bold.ttf", title_size)
-    f_sub = find_font("NotoSans-Regular.ttf", subtitle_size)
-    f_role = find_font("NotoSans-Light.ttf", role_size)
-    f_tags = find_font("NotoSans-Regular.ttf", tags_size)
+    f_title, title_exact = find_font("NotoSans-Bold.ttf", title_size)
+    f_sub, sub_exact = find_font("NotoSans-Regular.ttf", subtitle_size)
+    f_role, role_exact = find_font("NotoSans-Light.ttf", role_size)
+    f_tags, tags_exact = find_font("NotoSans-Regular.ttf", tags_size)
+
+    if not all([title_exact, sub_exact, role_exact, tags_exact]):
+        msg = ("Schriftgroessen nicht anwendbar (Pillow < 10.1 ohne size-Parameter), "
+               "Safe-Zone-Messung nicht belastbar")
+        violations.append(msg)
+        print(f"⚠️  WARNUNG: {msg}")
 
     # === LAYOUT ===
     y = SAFE_Y_MIN
@@ -268,7 +285,8 @@ if __name__ == "__main__":
     parser.add_argument("--book", default=None, help="Pfad zum Buchcover")
     parser.add_argument("--accent", default="0,200,255", help="Akzent-Farbe als R,G,B")
     parser.add_argument("--strict", action="store_true",
-                        help="Bei Safe-Zone-Verletzungen mit Exitcode 1 enden")
+                        help="Bei Safe-Zone-Verletzungen oder nicht belastbarer "
+                             "Messung mit Exitcode 1 enden")
     args = parser.parse_args()
 
     accent = tuple(int(x) for x in args.accent.split(","))

--- a/scripts/create_banner.py
+++ b/scripts/create_banner.py
@@ -3,15 +3,17 @@
 
 Verwendung:
     python scripts/create_banner.py \
-        --background background.png \
         --output banner.png \
         --title1 "Zeile 1" \
         --title2 "Zeile 2" \
         --subtitle "Untertitel" \
         --role "Position @ Unternehmen" \
         --tags "#GenAI  #EnterpriseAI" \
+        [--background background.png] \
         [--book cover.png] \
         [--accent 0,200,255]
+
+Ohne --background wird ein Gradient-Hintergrund erzeugt.
 """
 
 from PIL import Image, ImageDraw, ImageFont, ImageFilter
@@ -66,7 +68,7 @@ def create_linkedin_banner(
     Erstellt ein professionelles LinkedIn-Banner mit Safe-Zone-Validierung.
 
     Args:
-        background_path: Pfad zum Hintergrund-Bild
+        background_path: Pfad zum Hintergrund-Bild (None oder nicht vorhanden: Gradient-Fallback)
         output_path: Ausgabepfad für das Banner
         title_line1: Erste Titelzeile (max. ~22 Zeichen bei 52px)
         title_line2: Zweite Titelzeile (optional)
@@ -231,7 +233,8 @@ def create_linkedin_banner(
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="LinkedIn Banner Generator v2.0")
-    parser.add_argument("--background", required=True, help="Pfad zum Hintergrund-Bild")
+    parser.add_argument("--background", default=None,
+                        help="Pfad zum Hintergrund-Bild (optional, sonst Gradient-Fallback)")
     parser.add_argument("--output", required=True, help="Ausgabepfad")
     parser.add_argument("--title1", required=True, help="Erste Titelzeile")
     parser.add_argument("--title2", default="", help="Zweite Titelzeile")


### PR DESCRIPTION
## Was

Sechs Commits auf `fix/welle-2`, in zwei Blöcken.

**Personendaten und Landingpage**

1. `Ersetze reale Profildaten in den Beispielen durch Beispieldaten` (TEMPLATES.md, SCORING.md)
2. `Vereinheitliche die LinkedIn-URL im Footer der Landingpage` (index.html)

**create_banner.py**

3. `Entferne den ungenutzten Import sys aus create_banner.py`
4. `Mache --background optional in create_banner.py`
5. `Uebergib die angeforderte Schriftgroesse an den PIL-Default-Font`
6. `Gib Safe-Zone-Verletzungen zurueck und koppel --strict an den Exitcode`

## Warum

**Profildaten.** Die Headline-Beispiele in `references/TEMPLATES.md` und die Bewertungsstufen in `references/SCORING.md` zeigten Position, Arbeitgeber, Buchzahl und Fachmedien-Rolle einer realen Person. In einem öffentlichen Repo, das beschreibt, wie man fremde Profildaten verarbeitet, ist das die falsche Visitenkarte. Ersetzt ist durchgehend eine erkennbar erfundene Person: Head of Digital Platforms @ Musterwerke AG, Nische Logistik statt Energiewende, Pflicht-Hashtag `#WIRsindMusterwerke`. Die Logik des Rasters bleibt erhalten, Stufe 0–2 zeigt weiterhin nur den Jobtitel, Stufe 3–4 Jobtitel plus Unternehmen.

**Footer-URL.** Der Footer führte zwei verschiedene Profil-URLs für dieselbe Person. Geprüft wurden beide mit je fünf Abrufen: `/in/markzimmermann` liefert jedes Mal HTTP 999, also die Authwall ohne abrufbares Profil. `/in/mark-zimmermann-5a005123` liefert jedes Mal HTTP 200, trägt `<title>Mark Zimmermann - EnBW | LinkedIn</title>` und setzt `og:url` auf sich selbst, ohne Weiterleitung auf eine Custom-URL. Damit ist die zweite die kanonische Adresse. Der Link in der Created-by-Zeile zeigt jetzt ebenfalls dorthin, der Link rechts blieb unverändert. `index.html` wurde nur inhaltlich geändert, nicht verschoben (`git log --name-status` zeigt `M`, nicht `R`), und die Zahl der `<a>`-Tags ist mit 13 unverändert.

**Skript.** `import sys` war ungenutzt und hätte jeden Linter mit dem Standardregelsatz auf F401 rot gemacht. `--background` war `required=True`, obwohl der Gradient-Fallback seit jeher implementiert ist und Docstring wie `SKILL.md:203` ihn versprechen; ein Aufruf ohne das Argument brach in argparse ab, bevor die Logik lief. Die Safe-Zone-Prüfungen für Titel, Untertitel, Rolle, Tags, y-Überlauf und Buchcover schrieben ihr Ergebnis nur nach stdout, der Exit-Code blieb 0. `create_linkedin_banner` sammelt die Verletzungen jetzt in einer Liste und gibt `(Pfad, Verletzungen)` zurück; die bisherigen Warnungen auf stdout bleiben. Neu ist `--strict`, das die Liste auf stderr ausgibt und mit Exit-Code 1 endet. Ohne das Flag bleibt das Verhalten wie bisher.

Commit 5 sieht nach Zusatzarbeit aus, ist aber die Voraussetzung dafür, dass Commit 6 etwas bewirkt. Die Font-Suchpfade zeigen nur nach `/usr/share/fonts/truetype/*`; sonst griff `ImageFont.load_default()` ohne Größenangabe, also der Bitmap-Font mit rund 6px. Die Prüfung maß dann die Breite eines Fonts, der mit dem angeforderten nichts zu tun hat: ein 81 Zeichen langer Titel kam auf x=902 und blieb unter der Grenze von 1200, obwohl er bei 52px auf x=2341 läuft. Ein Exit-Code, der an eine solche Messung gekoppelt ist, sagt nichts aus. `load_default(size=...)` gibt es ab Pillow 10.1, ältere Versionen fallen auf den bisherigen Weg zurück und sagen das jetzt auch. In derselben Zeile ist ein f-String ohne Platzhalter weggefallen (F541, gehört wie F401 zum Standardregelsatz); die Commit-Message nennt das nicht, deshalb hier.

## Wie geprüft

Der Abnahmebefehl, ohne `--background`, mit zu langem Titel und `--strict`:

```
exit=1
stderr: ✗ 1 Safe-Zone-Verletzung(en):
  - Titel '...' ragt über Safe Zone (x=2341, max=1200)
```

Der Exit-Code kommt aus der Safe-Zone-Prüfung, nicht aus argparse. Zwei Gegenproben dazu: derselbe Titel ohne `--strict` endet bei 0 und zeigt die Warnung weiter; ein sauberes Banner mit `--strict` endet bei 0 ohne Verletzung.

Zum Vergleich derselbe Befehl auf `origin/main`:

```
exit=2
orig_banner.py: error: the following arguments are required: --background
```

Also der Fall, vor dem die Gegenprüfung gewarnt hat: ein Test, der bestanden hätte, ohne dass eine Validierung gelaufen wäre.

`git grep -n -i -E "enbw|head of coe|heise-fachautor|14\+ (KI|Fach)"` liefert keinen Treffer. `python3 -m py_compile` läuft durch.

Ein echter Linter-Lauf fehlt: ruff, pyflakes und flake8 sind auf der Maschine nicht installiert, und der Auftrag schließt neue Abhängigkeiten aus. Ersatzweise ein AST-Check auf F401 und F541, den ich gegen `origin/main` validiert habe. Dort meldet er `sys` in Zeile 20 und den f-String in Zeile 47, auf dem Endstand meldet er nichts.

## Was offen bleibt

Der grep nach dem Klarnamen liefert weiter drei Treffer, und das ist Absicht. `LICENSE:3` nennt den Copyright-Inhaber der MIT-Lizenz, `index.html:1120` ist die Created-by-Zeile, `index.html:1125` der Slug in der Profil-URL. Das ist Urheberangabe, keine Beispiel-Profildaten, und die Aufgabe verlangt im selben Atemzug, den richtigen LinkedIn-Link im Footer stehen zu lassen. Wer die Treffer trotzdem auf null bringen will, muss zuerst entscheiden, ob die Landingpage ohne Autorennennung auskommen soll.

Weiter offen, jeweils bewusst außerhalb dieses Auftrags:

- `references/BANNER.md` trägt eine abweichende Zweitfassung desselben Banner-Codes, mit hartem `assert` statt `print` und ohne Fallback-Suche beim Font. Nicht angeglichen.
- Das Aufrufbeispiel in `SKILL.md:193` kennt `--strict` noch nicht. Das Flag steht im Docstring und in `--help`.
- Die Font-Suchpfade bleiben Linux-only. Nur die Größenweitergabe an den letzten Fallback ist repariert.
- Kein `tests/test_banner.py`. Die zurückgegebene Verletzungsliste ist die Voraussetzung dafür und liegt jetzt vor.

Zwei Randnotizen für den, der pusht. Die abgeleiteten Werte in `TEMPLATES.md:25` waren schon vorher falsch (119 statt tatsächlich 116 Zeichen, das als 60 Zeichen ausgewiesene Präfix war 50 lang); sie sind für die neue Beispiel-Headline neu berechnet. Und die git-Konfiguration des Clones setzt `user.email` auf eine Adresse in der Domain des Arbeitgebers, die Commits tragen sie in den Autor-Metadaten. Das ist die bestehende Konfiguration des Eigentümers, deshalb habe ich sie nicht angefasst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BL7UoPomBp2Luhg89R6fYk

## Nacharbeit nach der Abnahme

Zwei Punkte kamen aus der Abnahme dazu.

Der an die Validierung gekoppelte Exitcode war als Opt-in umgesetzt, und das Opt-in wurde
nirgends gesetzt. Der einzige dokumentierte Aufruf in `SKILL.md` lief ohne `--strict`, die
Reparatur kam in der Auslieferung also nicht an. Jetzt traegt der dokumentierte Aufruf `--strict`
und kein `--background` mehr auf eine Datei, die es im Repo nicht gibt.

Der fail-closed-Pfad griff nur im Normalfall. Unter Pillow vor 10.1 fiel die Schriftwahl auf
einen Default ohne Groessenangabe zurueck, warnte, und `--strict` endete trotzdem mit 0.
Dieser Fall zaehlt jetzt selbst als Verletzung.

Beide Reparaturen sind gegen den kaputten Stand gemessen, nicht nur gegen den reparierten.

## Was bewusst offen bleibt

- Unter Pillow vor 10.1 wird der reale Titelueberlauf weiterhin nicht gemessen. Der Exitcode
  kommt dort aus der Ersatzverletzung, nicht aus der Messung.
- Ein gesetztes `--background` auf eine nicht existierende Datei faellt weiterhin still in den
  Gradient, auch mit `--strict`.
- Pillow ist nirgends gepinnt, es gibt keine `requirements.txt`.
- `references/BANNER.md` enthaelt ein zweites Code-Snippet ohne Fallback und ohne Safe-Zone-Pruefung.


---
Teil von Welle 2 des Haerteplans: erst lauffaehig, dann sichtbar. Jede Aenderung wurde von einem zweiten Durchgang abgenommen, der die Pruefungen selbst wiederholt hat.
