### PR TITLE
CI sichtbar machen und Aussagen richtigstellen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ defaults:
 jobs:
   checks:
     runs-on: ubuntu-latest
-    env:
-      # Haelt __pycache__ aus dem Arbeitsbaum; das Repo hat keine .gitignore.
-      PYTHONPYCACHEPREFIX: ${{ runner.temp }}/pycache
     steps:
       - uses: actions/checkout@v4
 
@@ -32,8 +29,10 @@ jobs:
       - name: Pillow installieren
         run: python -m pip install --disable-pip-version-check "Pillow>=10.1"
 
+      # PYTHONPYCACHEPREFIX haelt __pycache__ aus dem Arbeitsbaum,
+      # das Repo hat keine .gitignore.
       - name: Python-Syntax pruefen
-        run: python -m compileall -q scripts
+        run: PYTHONPYCACHEPREFIX="$RUNNER_TEMP/pycache" python -m compileall -q scripts
 
       - name: Node-Syntax pruefen
         run: node --check scripts/generate_report.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    env:
+      # Haelt __pycache__ aus dem Arbeitsbaum; das Repo hat keine .gitignore.
+      PYTHONPYCACHEPREFIX: ${{ runner.temp }}/pycache
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # Pillow >= 10.1, weil ImageFont.load_default() erst ab 10.1.0 einen
+      # size-Parameter kennt. Ohne den faellt create_banner.py auf einen
+      # Bitmap-Font in fester Groesse zurueck, meldet die Messung selbst als
+      # Safe-Zone-Verletzung und beendet --strict auch bei sauberem Text mit 1.
+      # Das Repo hat keine requirements.txt, die Untergrenze steht deshalb hier.
+      - name: Pillow installieren
+        run: python -m pip install --disable-pip-version-check "Pillow>=10.1"
+
+      - name: Python-Syntax pruefen
+        run: python -m compileall -q scripts
+
+      - name: Node-Syntax pruefen
+        run: node --check scripts/generate_report.js
+
+      - name: Banner ohne Verletzung endet mit 0
+        run: |
+          python scripts/create_banner.py \
+            --output "$RUNNER_TEMP/banner-clean.png" \
+            --title1 "Safe Zone" \
+            --title2 "CI Smoke Test" \
+            --subtitle "Kurzer Untertitel" \
+            --role "Beispielrolle @ Beispiel GmbH" \
+            --tags "#CI #SafeZone" \
+            --strict
+
+      - name: Banner mit Verletzung endet ungleich 0
+        run: |
+          rc=0
+          python scripts/create_banner.py \
+            --output "$RUNNER_TEMP/banner-broken.png" \
+            --title1 "Ein viel zu langer Titel der die Safe Zone garantiert nach rechts verlaesst" \
+            --strict 2> "$RUNNER_TEMP/banner-broken.err" || rc=$?
+          cat "$RUNNER_TEMP/banner-broken.err"
+          if [ "$rc" -eq 0 ]; then
+            echo "FEHLER: --strict hat die Safe-Zone-Verletzung nicht gemeldet" >&2
+            exit 1
+          fi
+          grep -q "Safe-Zone-Verletzung" "$RUNNER_TEMP/banner-broken.err"
+
+      - name: Versionsangaben pruefen
+        run: python scripts/check_versions.py

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Ein Skill zur professionellen Analyse und Optimierung von LinkedIn-Profilen. Ent
 | Content Skill | Personalisierter Posting-Skill mit 10 Hook-Typen |
 | Kommentar Skill | 5 Kommentar-Typen, 15–20 Ziel-Accounts |
 | SSI-Aktionsplan | Social Selling Index Optimierung (4 Säulen) |
-| PDF-Report | 10–15 Seiten mit Radar-Charts und 12-Monats-Roadmap |
+| DOCX-Report | Word-Dokument mit 9 Kapiteln, Scoring-Tabellen und Roadmap bis Monat 6 |
 
 ## Ordnerstruktur
 
@@ -42,6 +42,30 @@ LinkedInOptimizer/
 - Engagement-Benchmarks: Hootsuite 2025 (3,4% Plattform-Ø)
 - Top Voice Kriterien: Halbjährliche Review seit Januar 2025
 - SSI-Framework: 4 Säulen × 25 Punkte, Ziel ≥75
+
+## Scoring
+
+Die zehn Kategorien, ihre Gewichte und die Begründung je Gewicht stehen in [references/SCORING.md](references/SCORING.md#gewichtung). Dort liegen auch die [Engagement-Rate-Benchmarks](references/SCORING.md#engagement-rate-benchmarks-2025) samt Berechnungsformel und die [Score-Interpretation](references/SCORING.md#score-interpretation), die einen Gesamtscore in einen Zeithorizont bis Top Voice übersetzt.
+
+## Grenzen
+
+- LinkedIn blockiert web_fetch und web_search über robots.txt. Ohne das Chrome-Plugin bleibt die manuelle Eingabe, und die Datenqualität sinkt entsprechend.
+- Impressions sind öffentlich nicht sichtbar. `scripts/generate_report.js` schätzt die Engagement-Rate deshalb aus der Follower-Zahl, während die Benchmark-Tabelle in SCORING.md Impressions als Nenner voraussetzt. Der geschätzte Wert liegt systematisch höher als der Benchmark-Wert, beide sind nicht direkt vergleichbar.
+- Der DOCX-Report enthält keine Diagramme. Radar-Chart und Balkendiagramm sind in SCORING.md als Darstellungsform beschrieben, das Report-Template erzeugt sie nicht.
+- Der Ausgabepfad in `scripts/generate_report.js` steht fest auf `/mnt/user-data/outputs/`, also auf die Sandbox von claude.ai. Für einen lokalen Lauf muss die letzte Zeile angepasst werden.
+- Der SSI lässt sich nur mit Zugang zu linkedin.com/sales/ssi ablesen. Ohne Zugang wird er aus Profil-Signalen geschätzt und ist im Report als geschätzt zu kennzeichnen.
+- `scripts/create_banner.py` braucht Pillow ab 10.1. Ältere Versionen wenden die angeforderte Schriftgröße nicht auf den Ersatz-Font an; die Safe-Zone-Messung ist dann nicht belastbar, und `--strict` bricht ab.
+- Es gibt weder requirements.txt noch package.json. Pillow und das npm-Paket docx sind nicht gepinnt.
+
+## Roadmap
+
+Offene Punkte, ohne Termin:
+
+- requirements.txt und package.json mit gepinnten Versionen für Pillow und docx.
+- Ausgabepfad des Report-Templates konfigurierbar machen, statt ihn auf die claude.ai-Sandbox zu verdrahten.
+- Quellenangaben für die Engagement-Benchmarks in SCORING.md, dazu die Klärung, welcher Nenner gilt.
+- Fehlerfälle Rate Limit beziehungsweise LinkedIn-Checkpoint und geänderte DOM-Struktur in der Fehlerbehandlung ergänzen.
+- Testfälle für das Scoring mit erwarteten Score-Bändern.
 
 ## Version
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Ein Skill zur professionellen Analyse und Optimierung von LinkedIn-Profilen. Ent
 
 ```
 LinkedInOptimizer/
+├── README.md              # Diese Übersicht
 ├── SKILL.md               # Hauptworkflow (8 Phasen)
+├── LICENSE                # MIT-Lizenz
 ├── index.html             # Landingpage (GitHub Pages, Quelle ist der Repo-Root)
 ├── scripts/
 │   ├── create_banner.py   # Banner-Generator mit Safe-Zone-Validierung

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# linkedin-profil-optimierung v2.1
+# linkedin-profil-optimierung v2.2.2
+
+[![CI](https://github.com/GodModeAI2025/LinkedInOptimizer/actions/workflows/ci.yml/badge.svg)](https://github.com/GodModeAI2025/LinkedInOptimizer/actions/workflows/ci.yml)
 
 Ein Skill zur professionellen Analyse und Optimierung von LinkedIn-Profilen. Entwickelt für Berater, Agenturen und Freelancer, die Kunden strategisch als Thought Leader positionieren und auf das LinkedIn Top Voice Badge vorbereiten.
 
@@ -19,16 +21,19 @@ Ein Skill zur professionellen Analyse und Optimierung von LinkedIn-Profilen. Ent
 ## Ordnerstruktur
 
 ```
-linkedin-profil-skill-2/
-├── SKILL.md              # Hauptworkflow (8 Phasen, <500 Zeilen)
+LinkedInOptimizer/
+├── SKILL.md               # Hauptworkflow (8 Phasen)
+├── index.html             # Landingpage (GitHub Pages, Quelle ist der Repo-Root)
 ├── scripts/
-│   ├── create_banner.py  # Banner-Generator mit Safe-Zone-Validierung
-│   └── generate_report.js # DOCX-Report-Template (Node.js/docx-js)
+│   ├── create_banner.py   # Banner-Generator mit Safe-Zone-Validierung
+│   ├── check_versions.py  # Vergleicht die Versionsangaben in README, SKILL.md, index.html, Report-Template
+│   └── generate_report.js # DOCX-Report-Template (Node.js, npm-Paket docx)
 ├── references/
-│   ├── SCORING.md        # Gewichtete Bewertungsmatrix mit Sub-Kriterien
-│   ├── TEMPLATES.md      # Vorlagen für Headline, About, Content, Kommentare
-│   └── BANNER.md         # Technische Banner-Anleitung mit Viewport-Matrix
-└── assets/               # (Platzhalter für Kundenassets wie Logos, Covers)
+│   ├── SCORING.md         # Gewichtete Bewertungsmatrix mit Sub-Kriterien und Benchmarks
+│   ├── TEMPLATES.md       # Vorlagen für Headline, About, Content, Kommentare
+│   └── BANNER.md          # Technische Banner-Anleitung mit Viewport-Matrix
+└── .github/workflows/
+    └── ci.yml             # Syntax-, Banner- und Versionsprüfung
 ```
 
 ## Datenbasis
@@ -40,4 +45,4 @@ linkedin-profil-skill-2/
 
 ## Version
 
-v2.2.0 – Chrome-First Datenerhebung, DOCX als Pflicht-Deliverable, Report-Template in scripts/.
+Aktuelle Version: v2.2.2. Was sich je Version geändert hat, steht im Changelog in [SKILL.md](SKILL.md#changelog).

--- a/SKILL.md
+++ b/SKILL.md
@@ -24,7 +24,7 @@ Lies die jeweilige Datei, wenn du die Phase erreichst:
 | `references/TEMPLATES.md` | Vorlagen für Headline, About, Content-Skill, Kommentar-Skill | Phase 4 + 6 |
 | `references/BANNER.md` | Technische Banner-Anleitung mit Safe Zones und Viewport-Matrix | Phase 5 |
 | `scripts/create_banner.py` | Ausführbares Banner-Skript mit Font-Fallback und Validierung | Phase 5 (ausführen) |
-| `scripts/generate_report.js` | DOCX-Report-Template (Node.js/docx-js) — als Strukturvorlage nutzen und mit den erhobenen Daten befüllen | Phase 8 (anpassen + ausführen) |
+| `scripts/generate_report.js` | DOCX-Report-Template (Node.js, npm-Paket `docx`), als Strukturvorlage nutzen und mit den erhobenen Daten befüllen | Phase 8 (anpassen + ausführen) |
 
 ---
 
@@ -251,7 +251,7 @@ Der Analyse-Report wird immer als professionelles Word-Dokument (.docx) geliefer
 
 **Vorgehen:**
 1. Lies `scripts/generate_report.js` mit dem view-Tool
-2. Kopiere das Skript in das Arbeitsverzeichnis
+2. Kopiere es unter dem Namen `generate_report.js` in das Arbeitsverzeichnis
 3. Ersetze die Platzhalter-Daten durch die erhobenen Kundendaten:
    - `scoring`-Array: Alle 10 Kategorien mit Roh-Score, Gewichtung, Begründung
    - `posts`-Array: Content-Aktivitäten aus Phase 1 (Schritt 2)
@@ -260,8 +260,9 @@ Der Analyse-Report wird immer als professionelles Word-Dokument (.docx) geliefer
    - About-Analyse: Verbotene Wörter, CTA-Bewertung, Hashtag-Status
    - Profil-Audit: 17-Punkte-Checkliste mit Status je Element
    - Roadmap: Kundenspezifisch priorisierte Maßnahmen
-4. Führe das Skript aus: `node report.js`
-5. Validiere das Ergebnis: `python scripts/office/validate.py output.docx`
+4. Passe die letzte Zeile an: der Ausgabepfad steht fest auf `/mnt/user-data/outputs/`. Außerhalb der claude.ai-Sandbox muss dort ein existierendes Verzeichnis stehen.
+5. Führe das Skript aus: `node generate_report.js`. Es schreibt den Pfad der erzeugten Datei als `Done: …` nach stdout.
+6. Prüfe das Ergebnis: `unzip -l <Ausgabedatei>.docx` muss `word/document.xml` listen, danach die Datei öffnen und die 9 Kapitel durchgehen.
 
 **Report-Struktur (9 Kapitel, alle mit erklärenden Textpassagen):**
 
@@ -341,7 +342,7 @@ Prüfe vor Übergabe an den Kunden:
 
 **Scoring**: Jede Kategorie mit Begründung, gewichtete Summe korrekt berechnet, ≥3 Hebel identifiziert.
 
-**Report**: DOCX generiert und validiert (validate.py bestanden), alle 9 Kapitel vorhanden, jede Tabelle und jedes Diagramm hat einen erklärenden Textabsatz darunter, keine Scoring-Kategorie ohne Begründung.
+**Report**: DOCX erzeugt, als ZIP lesbar (`unzip -l` listet `word/document.xml`), alle 9 Kapitel vorhanden, jede Tabelle und jedes Diagramm hat einen erklärenden Textabsatz darunter, keine Scoring-Kategorie ohne Begründung.
 
 Bei Fehlern: Automatisch korrigieren und erneut prüfen.
 
@@ -365,7 +366,7 @@ Bei Fehlern: Automatisch korrigieren und erneut prüfen.
 
 **Banner-Erstellung scheitert**: Font-Fallback (DejaVuSans) und Gradient-Fallback sind im Skript eingebaut. Wenn Buchcover nicht in Safe Zone passt: weglassen.
 
-**DOCX-Generierung scheitert**: Prüfe ob `docx` npm-Paket installiert ist (`npm install -g docx`). Validiere das Ergebnis mit `python scripts/office/validate.py`. Bei Syntax-Fehlern im Report-Skript: Keine typografischen Anführungszeichen (U+201E, U+201C) in JavaScript-Strings verwenden — nur ASCII-Quotes (`"` und `'`). Umlaute (ä, ö, ü, ß) und andere UTF-8-Zeichen sind dagegen problemlos möglich und sollen immer korrekt geschrieben werden — niemals als ASCII-Umschreibungen (ae, oe, ue, ss).
+**DOCX-Generierung scheitert**: Prüfe ob das npm-Paket `docx` installiert ist (`npm install -g docx`). Prüfe das Ergebnis mit `unzip -l <Ausgabedatei>.docx`, `word/document.xml` muss enthalten sein. Bei Syntax-Fehlern im Report-Skript: Keine typografischen Anführungszeichen (U+201E, U+201C) in JavaScript-Strings verwenden — nur ASCII-Quotes (`"` und `'`). Umlaute (ä, ö, ü, ß) und andere UTF-8-Zeichen sind dagegen problemlos möglich und sollen immer korrekt geschrieben werden — niemals als ASCII-Umschreibungen (ae, oe, ue, ss).
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -251,7 +251,7 @@ Der Analyse-Report wird immer als professionelles Word-Dokument (.docx) geliefer
 
 **Vorgehen:**
 1. Lies `scripts/generate_report.js` mit dem view-Tool
-2. Kopiere es unter dem Namen `generate_report.js` in das Arbeitsverzeichnis
+2. Kopiere es unter dem Namen `generate_report.js` in das Arbeitsverzeichnis und installiere dort das Paket `docx` mit `npm install docx`
 3. Ersetze die Platzhalter-Daten durch die erhobenen Kundendaten:
    - `scoring`-Array: Alle 10 Kategorien mit Roh-Score, Gewichtung, Begründung
    - `posts`-Array: Content-Aktivitäten aus Phase 1 (Schritt 2)
@@ -280,7 +280,7 @@ Der Analyse-Report wird immer als professionelles Word-Dokument (.docx) geliefer
 
 7. **Profil-Audit** (1 Seite): 17-Punkte-Checkliste als Tabelle mit Status (Vorhanden/Fehlt/Teilweise) und konkreter Maßnahme je Element. Zusammenfassung: X von 17 erfüllt.
 
-8. **Roadmap** (1 Seite): Zeitlich priorisierte Maßnahmen (Woche 1–2 Quick Wins → Monat 2–3 Skalierung → Monat 4–6 Authority Building). Erwarteter Score nach 3 Monaten mit Begründung.
+8. **Roadmap** (1 Seite): Zeitlich priorisierte Maßnahmen (Woche 1–2 Quick Wins → Woche 3–4 Content-Start → Monat 2–3 Skalierung → Monat 4–6 Authority Building). Erwarteter Score nach 3 Monaten mit Begründung.
 
 9. **Methodik & Einschränkungen** (1 Seite): Wie die Daten erhoben wurden (Chrome/web_search/manuell), welche Scoring-Methodik verwendet wurde, welche Daten geschätzt oder nicht verfügbar waren. Transparenz schafft Vertrauen.
 
@@ -342,7 +342,7 @@ Prüfe vor Übergabe an den Kunden:
 
 **Scoring**: Jede Kategorie mit Begründung, gewichtete Summe korrekt berechnet, ≥3 Hebel identifiziert.
 
-**Report**: DOCX erzeugt, als ZIP lesbar (`unzip -l` listet `word/document.xml`), alle 9 Kapitel vorhanden, jede Tabelle und jedes Diagramm hat einen erklärenden Textabsatz darunter, keine Scoring-Kategorie ohne Begründung.
+**Report**: DOCX erzeugt, als ZIP lesbar (`unzip -l` listet `word/document.xml`), alle 9 Kapitel vorhanden, jede Tabelle hat einen erklärenden Textabsatz darunter, keine Scoring-Kategorie ohne Begründung.
 
 Bei Fehlern: Automatisch korrigieren und erneut prüfen.
 
@@ -362,11 +362,11 @@ Bei Fehlern: Automatisch korrigieren und erneut prüfen.
 
 **SSI nicht verfügbar**: Erfordert Zugang zu linkedin.com/sales/ssi. Schätze die 4 Säulen basierend auf beobachtbaren Profil-Signalen. Markiere als "(geschätzt)" im Report.
 
-**Wettbewerber nicht abrufbar**: Minimum 2 Wettbewerber für sinnvolle Matrix. Bei <2: Branchenbenchmarks aus der Tabelle oben verwenden.
+**Wettbewerber nicht abrufbar**: Das Quality Gate für Phase 3 verlangt 3 Wettbewerber. Sind nur 2 erreichbar, erstelle die Matrix mit 2 und vermerke die Abweichung im Report. Bei <2: Branchenbenchmarks aus der Tabelle oben verwenden.
 
 **Banner-Erstellung scheitert**: Font-Fallback (DejaVuSans) und Gradient-Fallback sind im Skript eingebaut. Wenn Buchcover nicht in Safe Zone passt: weglassen.
 
-**DOCX-Generierung scheitert**: Prüfe ob das npm-Paket `docx` installiert ist (`npm install -g docx`). Prüfe das Ergebnis mit `unzip -l <Ausgabedatei>.docx`, `word/document.xml` muss enthalten sein. Bei Syntax-Fehlern im Report-Skript: Keine typografischen Anführungszeichen (U+201E, U+201C) in JavaScript-Strings verwenden — nur ASCII-Quotes (`"` und `'`). Umlaute (ä, ö, ü, ß) und andere UTF-8-Zeichen sind dagegen problemlos möglich und sollen immer korrekt geschrieben werden — niemals als ASCII-Umschreibungen (ae, oe, ue, ss).
+**DOCX-Generierung scheitert**: Prüfe ob das npm-Paket `docx` im Arbeitsverzeichnis installiert ist (`npm install docx`). Eine globale Installation reicht nicht: `require("docx")` durchsucht nur die node_modules-Ordner oberhalb des Skripts, nicht das globale npm-Verzeichnis. Prüfe das Ergebnis mit `unzip -l <Ausgabedatei>.docx`, `word/document.xml` muss enthalten sein. Bei Syntax-Fehlern im Report-Skript: Keine typografischen Anführungszeichen (U+201E, U+201C) in JavaScript-Strings verwenden — nur ASCII-Quotes (`"` und `'`). Umlaute (ä, ö, ü, ß) und andere UTF-8-Zeichen sind dagegen problemlos möglich und sollen immer korrekt geschrieben werden — niemals als ASCII-Umschreibungen (ae, oe, ue, ss).
 
 ---
 
@@ -376,7 +376,7 @@ Bei Fehlern: Automatisch korrigieren und erneut prüfen.
 |-------|------|---------|
 | 1. Discovery | Alle Profildaten vollständig | Checkliste |
 | 2. Scoring | Jeder Score mit Begründung | Sub-Kriterien aus SCORING.md |
-| 3. Wettbewerb | Min. 3 Wettbewerber | Matrix ausgefüllt |
+| 3. Wettbewerb | Min. 3 Wettbewerber, Ausnahme siehe Fehlerbehandlung | Matrix ausgefüllt |
 | 4. Profil | Headline in 60-Zeichen-Preview geprüft | Zeichenzahl-Check |
 | 5. Banner | Kein Overlap in Safe Zone | Skript-Validierung |
 | 6. Content | 3 Test-Posts auf Tonalität geprüft | Template-Check |
@@ -391,7 +391,7 @@ Bei Fehlern: Automatisch korrigieren und erneut prüfen.
 v2.2.2 (2026-03-09) – Template anonymisiert
 ├── generate_report.js: Komplett neu geschrieben mit PROFILE/EXEC/HEADLINE/ABOUT/AUDIT/ROADMAP/LIMITS-Variablen
 ├── Report-Body ist jetzt 100% generisch — keine Namen, Firmen oder profilspezifischen Texte im Code
-├── Alle kundenspezifischen Daten stehen ausschließlich im KUNDENDATEN-Block (Zeile 80-150)
+├── Alle kundenspezifischen Daten stehen ausschließlich im KUNDENDATEN-Block (PROFILE bis LIMITS, Zeile 32-149)
 ├── Platzhalter-Werte ("Max Mustermann", "[Begründung]") als Vorlage für Anpassung
 └── Template von 585 auf 278 Zeilen reduziert (gleiche Report-Struktur, kompakterer Code)
 
@@ -412,7 +412,7 @@ v2.2.0 (2026-03-09) – Chrome-First + DOCX-Pflicht
 └── Verifikation: Report-Check auf DOCX-Validierung und Erklärungspflicht angepasst
 
 v2.1.0 (2026-03-09) – Anthropic Skill Standard Compliance
-├── Ordnerstruktur: references/, scripts/, assets/ nach Anthropic-Standard
+├── Ordnerstruktur: references/ und scripts/ nach Anthropic-Standard
 ├── SKILL.md auf <500 Zeilen reduziert mit klaren Verweisen auf references/
 ├── Banner-Code als eigenständiges Skript extrahiert (scripts/create_banner.py)
 ├── Font-Fallback (DejaVuSans) und Gradient-Fallback eingebaut

--- a/SKILL.md
+++ b/SKILL.md
@@ -10,7 +10,7 @@ description: >
   oder wenn jemand seinen LinkedIn-Auftritt professionalisieren möchte.
 ---
 
-# LinkedIn Profil-Optimierung & Thought-Leader Skill v2.2
+# LinkedIn Profil-Optimierung & Thought-Leader Skill v2.2.2
 
 Ein evidenzbasierter 8-Phasen-Workflow zur Analyse und Optimierung von LinkedIn-Profilen. Basiert auf LinkedIn-Algorithmus-Daten 2025/2026, Engagement-Benchmarks und den offiziellen Top Voice Kriterien.
 

--- a/index.html
+++ b/index.html
@@ -801,7 +801,7 @@ footer .footer-right a:hover { color: var(--text); }
   <div class="hero-content">
     <div class="hero-badge">
       <span class="dot"></span>
-      v2.2 · Claude Cowork Skill · MIT License
+      v2.2.2 · Claude Cowork Skill · MIT License
     </div>
     <h1>LinkedIn Profile<br><span class="gradient">Intelligence.</span></h1>
     <p>Professionelle Profilanalyse mit gewichtetem Scoring, Headline-Optimierung, Banner-Erstellung, Content-Strategie und PDF-Report. Evidenzbasiert auf LinkedIn-Algorithmus-Daten 2025/2026.</p>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>LinkedIn Optimizer – AI-Powered Profile Intelligence</title>
-<meta name="description" content="Claude Cowork Skill für professionelle LinkedIn-Profilanalyse: Gewichtetes Scoring, Headline-Optimierung, Banner-Erstellung, Content-Strategie und PDF-Report.">
+<meta name="description" content="Claude Cowork Skill für professionelle LinkedIn-Profilanalyse: Gewichtetes Scoring, Headline-Optimierung, Banner-Erstellung, Content-Strategie und DOCX-Report.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
@@ -529,7 +529,7 @@ section {
 .score-row .label {
   font-size: 0.82rem;
   color: var(--text-muted);
-  min-width: 130px;
+  min-width: 190px;
 }
 
 .score-row .bar-bg {
@@ -551,7 +551,7 @@ section {
   font-family: var(--mono);
   font-size: 0.78rem;
   color: var(--text-dim);
-  min-width: 30px;
+  min-width: 38px;
   text-align: right;
 }
 
@@ -584,7 +584,7 @@ section {
   stroke-width: 8;
   stroke-linecap: round;
   stroke-dasharray: 565;
-  stroke-dashoffset: 150;
+  stroke-dashoffset: 170;
   transition: stroke-dashoffset 2s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
@@ -804,7 +804,7 @@ footer .footer-right a:hover { color: var(--text); }
       v2.2.2 · Claude Cowork Skill · MIT License
     </div>
     <h1>LinkedIn Profile<br><span class="gradient">Intelligence.</span></h1>
-    <p>Professionelle Profilanalyse mit gewichtetem Scoring, Headline-Optimierung, Banner-Erstellung, Content-Strategie und PDF-Report. Evidenzbasiert auf LinkedIn-Algorithmus-Daten 2025/2026.</p>
+    <p>Professionelle Profilanalyse mit gewichtetem Scoring, Headline-Optimierung, Banner-Erstellung, Content-Strategie und DOCX-Report. Evidenzbasiert auf LinkedIn-Algorithmus-Daten 2025/2026.</p>
     <div class="hero-buttons">
       <a href="https://github.com/GodModeAI2025/LinkedInOptimizer" class="btn-primary" target="_blank">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
@@ -820,7 +820,7 @@ footer .footer-right a:hover { color: var(--text); }
   <div class="stat"><div class="num">10</div><div class="label">Scoring-Kategorien</div></div>
   <div class="stat"><div class="num">9</div><div class="label">Deliverables</div></div>
   <div class="stat"><div class="num">8</div><div class="label">Workflow-Phasen</div></div>
-  <div class="stat"><div class="num">15+</div><div class="label">Seiten PDF-Report</div></div>
+  <div class="stat"><div class="num">9</div><div class="label">Kapitel im DOCX-Report</div></div>
 </div>
 
 <!-- ─── Demo Chat ─── -->
@@ -839,7 +839,7 @@ footer .footer-right a:hover { color: var(--text); }
       <div class="chat-body">
         <div class="chat-msg user">Analysiere mein LinkedIn-Profil und gib mir einen Score.</div>
         <div class="chat-msg ai">Ich starte die 10-Kategorien-Analyse deines Profils mit gewichteter Bewertung…</div>
-        <div class="chat-msg ai">📊 Profil-Score: <strong>62/100</strong><br>Headline: 45 · About: 58 · Experience: 72<br>Top-Hebel: Headline (+18 Punkte möglich)</div>
+        <div class="chat-msg ai">📊 Profil-Score: <strong>70/100</strong><br>Headline 8/10 · About-Sektion 7/10 · Content-Qualität 6/10<br>Größter Hebel: Content-Qualität, bis zu 6,0 gewichtete Punkte</div>
         <div class="chat-msg user">Optimiere meine Headline.</div>
         <div class="chat-msg ai">Hier sind 3 Varianten mit SEO-Score, Zeichenzahl und Begründung…</div>
       </div>
@@ -852,7 +852,7 @@ footer .footer-right a:hover { color: var(--text); }
 <section id="deliverables">
   <div class="section-label">Deliverables</div>
   <div class="section-title">Alles, was dein LinkedIn-Profil braucht.</div>
-  <p class="section-sub">9 konkrete Ergebnisse – von der Analyse bis zum druckfertigen PDF-Report.</p>
+  <p class="section-sub">9 konkrete Ergebnisse, von der Analyse bis zum fertigen DOCX-Report.</p>
 
   <div class="deliverables-grid">
     <div class="deliverable">
@@ -897,8 +897,8 @@ footer .footer-right a:hover { color: var(--text); }
     </div>
     <div class="deliverable">
       <div class="d-icon">📑</div>
-      <h3>PDF-Report</h3>
-      <p>10–15 Seiten mit Radar-Charts, Kategorien-Breakdown und 12-Monats-Roadmap.</p>
+      <h3>DOCX-Report</h3>
+      <p>Word-Dokument mit 9 Kapiteln: Scoring-Tabellen, Detailanalyse je Kategorie und Roadmap bis Monat 6.</p>
     </div>
   </div>
 </section>
@@ -907,58 +907,59 @@ footer .footer-right a:hover { color: var(--text); }
 <section id="scoring">
   <div class="section-label">Scoring Engine</div>
   <div class="section-title">10 Kategorien. Gewichtet. Evidenzbasiert.</div>
+  <p class="section-sub">Kategorien und Gewichte stehen in <a href="https://github.com/GodModeAI2025/LinkedInOptimizer/blob/main/references/SCORING.md#gewichtung">references/SCORING.md</a>. Die Werte unten sind die dort durchgerechnete Beispielbewertung: Rohscores von 0 bis 10, gewichtet ergeben sie 70,0 von 100.</p>
 
   <div class="score-preview">
     <div class="score-categories">
       <div class="score-row">
-        <span class="label">Headline</span>
-        <div class="bar-bg"><div class="bar-fill" style="width:85%"></div></div>
-        <span class="val">85</span>
-      </div>
-      <div class="score-row">
-        <span class="label">About</span>
-        <div class="bar-bg"><div class="bar-fill" style="width:72%"></div></div>
-        <span class="val">72</span>
-      </div>
-      <div class="score-row">
-        <span class="label">Experience</span>
-        <div class="bar-bg"><div class="bar-fill" style="width:90%"></div></div>
-        <span class="val">90</span>
-      </div>
-      <div class="score-row">
-        <span class="label">Skills & Endorsements</span>
-        <div class="bar-bg"><div class="bar-fill" style="width:65%"></div></div>
-        <span class="val">65</span>
-      </div>
-      <div class="score-row">
-        <span class="label">Recommendations</span>
-        <div class="bar-bg"><div class="bar-fill" style="width:40%"></div></div>
-        <span class="val">40</span>
-      </div>
-      <div class="score-row">
-        <span class="label">Visual Branding</span>
-        <div class="bar-bg"><div class="bar-fill" style="width:55%"></div></div>
-        <span class="val">55</span>
-      </div>
-      <div class="score-row">
-        <span class="label">Content Activity</span>
-        <div class="bar-bg"><div class="bar-fill" style="width:78%"></div></div>
-        <span class="val">78</span>
-      </div>
-      <div class="score-row">
-        <span class="label">Network Quality</span>
-        <div class="bar-bg"><div class="bar-fill" style="width:82%"></div></div>
-        <span class="val">82</span>
-      </div>
-      <div class="score-row">
-        <span class="label">SEO / Keywords</span>
+        <span class="label">Content-Qualität (15%)</span>
         <div class="bar-bg"><div class="bar-fill" style="width:60%"></div></div>
-        <span class="val">60</span>
+        <span class="val">6/10</span>
       </div>
       <div class="score-row">
-        <span class="label">Featured Section</span>
-        <div class="bar-bg"><div class="bar-fill" style="width:35%"></div></div>
-        <span class="val">35</span>
+        <span class="label">Engagement &amp; Kommentare (15%)</span>
+        <div class="bar-bg"><div class="bar-fill" style="width:70%"></div></div>
+        <span class="val">7/10</span>
+      </div>
+      <div class="score-row">
+        <span class="label">Headline (12%)</span>
+        <div class="bar-bg"><div class="bar-fill" style="width:80%"></div></div>
+        <span class="val">8/10</span>
+      </div>
+      <div class="score-row">
+        <span class="label">About-Sektion (12%)</span>
+        <div class="bar-bg"><div class="bar-fill" style="width:70%"></div></div>
+        <span class="val">7/10</span>
+      </div>
+      <div class="score-row">
+        <span class="label">Social Proof (10%)</span>
+        <div class="bar-bg"><div class="bar-fill" style="width:90%"></div></div>
+        <span class="val">9/10</span>
+      </div>
+      <div class="score-row">
+        <span class="label">Posting-Frequenz (10%)</span>
+        <div class="bar-bg"><div class="bar-fill" style="width:50%"></div></div>
+        <span class="val">5/10</span>
+      </div>
+      <div class="score-row">
+        <span class="label">Netzwerk &amp; Follower (8%)</span>
+        <div class="bar-bg"><div class="bar-fill" style="width:80%"></div></div>
+        <span class="val">8/10</span>
+      </div>
+      <div class="score-row">
+        <span class="label">Profil-Vollständigkeit (7%)</span>
+        <div class="bar-bg"><div class="bar-fill" style="width:60%"></div></div>
+        <span class="val">6/10</span>
+      </div>
+      <div class="score-row">
+        <span class="label">Banner (6%)</span>
+        <div class="bar-bg"><div class="bar-fill" style="width:90%"></div></div>
+        <span class="val">9/10</span>
+      </div>
+      <div class="score-row">
+        <span class="label">Top Voice Readiness (5%)</span>
+        <div class="bar-bg"><div class="bar-fill" style="width:50%"></div></div>
+        <span class="val">5/10</span>
       </div>
     </div>
 
@@ -975,7 +976,7 @@ footer .footer-right a:hover { color: var(--text); }
           <circle class="fg" cx="100" cy="100" r="90"/>
         </svg>
         <div class="value">
-          <span class="number">73</span>
+          <span class="number">70</span>
           <span class="of">von 100</span>
         </div>
       </div>
@@ -988,7 +989,7 @@ footer .footer-right a:hover { color: var(--text); }
 <section id="workflow">
   <div class="section-label">Workflow</div>
   <div class="section-title">8 Phasen. Strukturiert. Reproduzierbar.</div>
-  <p class="section-sub">Vom Profil-Scraping über die Analyse bis zum fertigen PDF-Report – jede Phase baut auf der vorherigen auf.</p>
+  <p class="section-sub">Vom Profil-Scraping über die Analyse bis zum fertigen DOCX-Report, jede Phase baut auf der vorherigen auf.</p>
 
   <div class="phases">
     <div class="phase">
@@ -1043,8 +1044,8 @@ footer .footer-right a:hover { color: var(--text); }
     <div class="phase">
       <div class="num"></div>
       <div class="phase-content">
-        <h3>PDF-Report</h3>
-        <p>10–15 Seiten DOCX mit Radar-Charts, Kategorien-Breakdown und 12-Monats-Roadmap.</p>
+        <h3>DOCX-Report</h3>
+        <p>Word-Dokument mit 9 Kapiteln, Scoring-Tabellen und Roadmap bis Monat 6.</p>
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -839,7 +839,7 @@ footer .footer-right a:hover { color: var(--text); }
       <div class="chat-body">
         <div class="chat-msg user">Analysiere mein LinkedIn-Profil und gib mir einen Score.</div>
         <div class="chat-msg ai">Ich starte die 10-Kategorien-Analyse deines Profils mit gewichteter Bewertung…</div>
-        <div class="chat-msg ai">📊 Profil-Score: <strong>70/100</strong><br>Headline 8/10 · About-Sektion 7/10 · Content-Qualität 6/10<br>Größter Hebel: Content-Qualität, bis zu 6,0 gewichtete Punkte</div>
+        <div class="chat-msg ai">📊 Profil-Score: <strong>70/100</strong><br>Headline 8/10 · About-Sektion 7/10 · Content-Qualität 6/10 · Posting-Frequenz 5/10<br>Größter Hebel: Posting-Frequenz, 5,0 von 10 möglichen gewichteten Punkten</div>
         <div class="chat-msg user">Optimiere meine Headline.</div>
         <div class="chat-msg ai">Hier sind 3 Varianten mit SEO-Score, Zeichenzahl und Begründung…</div>
       </div>

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""Prueft, ob die Skill-Version an allen dokumentierten Stellen uebereinstimmt.
+
+Geprueft werden fuenf Fundstellen: die Ueberschrift und der Versions-Abschnitt
+der README, die Ueberschrift und der oberste Changelog-Eintrag in SKILL.md, das
+Hero-Badge der Landingpage und der DOCX-Kopfzeilen-String im Report-Template.
+
+Exitcode 0, wenn alle fuenf dieselbe Version nennen. Exitcode 1, wenn sie
+auseinanderlaufen oder wenn eine Fundstelle gar nicht mehr gefunden wird. Der
+zweite Fall ist Absicht: eine geloeschte oder umformulierte Versionszeile darf
+nicht stillschweigend durchgehen.
+
+Die Dokument-Versionen von references/SCORING.md (v2.0) sind bewusst nicht Teil
+der Pruefung, sie zaehlen eigenstaendig.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+VERSION = r"(\d+\.\d+\.\d+)"
+
+CHECKS = [
+    (
+        "README.md",
+        "Ueberschrift",
+        re.compile(r"^# linkedin-profil-optimierung v" + VERSION + r"\s*$", re.M),
+    ),
+    (
+        "README.md",
+        "Abschnitt Version",
+        re.compile(r"^Aktuelle Version: v" + VERSION + r"\b", re.M),
+    ),
+    (
+        "SKILL.md",
+        "Ueberschrift",
+        re.compile(r"^# LinkedIn Profil-Optimierung .* Skill v" + VERSION + r"\s*$", re.M),
+    ),
+    (
+        "SKILL.md",
+        "oberster Changelog-Eintrag",
+        re.compile(r"## Changelog\s*\n+```\s*\nv" + VERSION + r" \("),
+    ),
+    (
+        "index.html",
+        "Hero-Badge",
+        re.compile(r"v" + VERSION + r" &middot; Claude Cowork Skill|v" + VERSION + r" · Claude Cowork Skill"),
+    ),
+    (
+        "scripts/generate_report.js",
+        "DOCX-Kopfzeile",
+        re.compile(r'"linkedin-profil-optimierung v' + VERSION + r'"'),
+    ),
+]
+
+
+def main():
+    found = []
+    missing = []
+
+    for rel_path, label, pattern in CHECKS:
+        path = ROOT / rel_path
+        if not path.exists():
+            missing.append(f"{rel_path} ({label}): Datei fehlt")
+            continue
+        match = pattern.search(path.read_text(encoding="utf-8"))
+        if match is None:
+            missing.append(f"{rel_path} ({label}): Versionsangabe nicht gefunden")
+            continue
+        version = next(g for g in match.groups() if g)
+        found.append((rel_path, label, version))
+
+    for rel_path, label, version in found:
+        print(f"  v{version:<8} {rel_path} ({label})")
+
+    if missing:
+        print("\nFEHLER: Versionsangaben nicht auffindbar:", file=sys.stderr)
+        for entry in missing:
+            print(f"  - {entry}", file=sys.stderr)
+        return 1
+
+    versions = {version for _, _, version in found}
+    if len(versions) > 1:
+        print(
+            "\nFEHLER: Versionsangaben laufen auseinander: "
+            + ", ".join(sorted("v" + v for v in versions)),
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"\nOK: alle {len(found)} Fundstellen nennen v{versions.pop()}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_report.js
+++ b/scripts/generate_report.js
@@ -168,7 +168,7 @@ const doc = new Document({
     { reference: "numbers", levels: [{ level: 0, format: LevelFormat.DECIMAL, text: "%1.", alignment: AlignmentType.LEFT, style: { paragraph: { indent: { left: 720, hanging: 360 } } } }] },
   ]},
   sections: [{ properties: { page: { size: { width: 11906, height: 16838 }, margin: { top: 1440, right: 1440, bottom: 1440, left: 1440 } } },
-    headers: { default: new Header({ children: [new Paragraph({ border: { bottom: { style: BorderStyle.SINGLE, size: 4, color: BLUE, space: 6 } }, children: [ new TextRun({ text: "LinkedIn Profil-Analyse", size: 16, font: "Arial", color: GRAY }), new TextRun({ text: "\t" }), new TextRun({ text: "linkedin-profil-optimierung v2.2", size: 16, font: "Arial", color: GRAY }) ], tabStops: [{ type: TabStopType.RIGHT, position: TabStopPosition.MAX }] })] }) },
+    headers: { default: new Header({ children: [new Paragraph({ border: { bottom: { style: BorderStyle.SINGLE, size: 4, color: BLUE, space: 6 } }, children: [ new TextRun({ text: "LinkedIn Profil-Analyse", size: 16, font: "Arial", color: GRAY }), new TextRun({ text: "\t" }), new TextRun({ text: "linkedin-profil-optimierung v2.2.2", size: 16, font: "Arial", color: GRAY }) ], tabStops: [{ type: TabStopType.RIGHT, position: TabStopPosition.MAX }] })] }) },
     footers: { default: new Footer({ children: [new Paragraph({ border: { top: { style: BorderStyle.SINGLE, size: 2, color: "CCCCCC", space: 6 } }, alignment: AlignmentType.CENTER, children: [ new TextRun({ text: "Seite ", size: 16, font: "Arial", color: GRAY }), new TextRun({ children: [PageNumber.CURRENT], size: 16, font: "Arial", color: GRAY }) ] })] }) },
     children: [
       // ═══ TITELSEITE ═══


### PR DESCRIPTION
CI und Richtigstellungen (Welle 3)

## Was die CI prueft

Der Workflow .github/workflows/ci.yml laeuft auf ubuntu-latest, bei push und pull_request auf main sowie per workflow_dispatch. Er zieht nur actions/checkout@v4 und actions/setup-python@v5. Node kommt aus der Vorinstallation des Runners, dafuer wird keine weitere Action gebraucht.

Sechs Schritte, jeder mit einem realistischen Bruch dahinter:

1. Pillow installieren, festgelegt auf >= 10.1. Die Grenze ist nicht beliebig: ImageFont.load_default() kennt den size-Parameter erst ab 10.1.0. Darunter faellt create_banner.py auf einen Bitmap-Font in fester Groesse zurueck, und seit Welle 2 zaehlt genau dieser Fall selbst als Safe-Zone-Verletzung, weil die gemessenen Textbreiten dann aus einer anderen Schriftgroesse stammen. Mit einer aelteren Pillow-Version wuerde also schon der saubere Lauf mit Exitcode 1 enden. Das Repo hat keine requirements.txt, deshalb steht die Untergrenze im Workflow.
2. Python-Syntax ueber scripts/ (compileall).
3. Node-Syntax ueber scripts/generate_report.js. Der praktisch haeufigste Bruch steht in SKILL.md selbst beschrieben: typografische Anfuehrungszeichen in JavaScript-Strings beim Anpassen der Kundendaten.
4. create_banner.py --strict mit kurzen Texten muss mit 0 enden.
5. create_banner.py --strict mit einem zu langen Titel muss ungleich 0 enden, und die Fehlermeldung muss "Safe-Zone-Verletzung" enthalten. Der zweite Teil ist wichtig, weil ein beliebiger Traceback ebenfalls Exitcode 1 liefert und sonst als bestandener Test durchginge. Die Schritte 4 und 5 zusammen sichern die Welle-2-Reparatur ab.
6. scripts/check_versions.py vergleicht sechs Versionsfundstellen: README-Ueberschrift, README-Abschnitt Version, SKILL.md-Ueberschrift, oberster Changelog-Eintrag, Hero-Badge der Landingpage, DOCX-Kopfzeile im Report-Template. Das Skript endet auch dann mit 1, wenn eine Fundstelle gar nicht mehr gefunden wird, damit eine geloeschte Versionszeile nicht stillschweigend durchgeht.

Alle sechs Schritte wurden lokal Zeile fuer Zeile so ausgefuehrt, wie sie im Workflow stehen, unter bash -eo pipefail. Alle gruen, der Arbeitsbaum bleibt danach sauber.

## Was die CI nicht prueft

- Die Report-Erzeugung. node --check parst die Datei, fuehrt sie aber nicht aus. Das npm-Paket docx ist nicht installiert, und der Ausgabepfad steht fest auf die claude.ai-Sandbox.
- Ob die zehn Kategorien auf der Landingpage weiterhin zu SCORING.md passen. Sie wurden in diesem PR von Hand angeglichen, gegen erneutes Auseinanderlaufen gibt es noch keinen Check. Das waere der naechste sinnvolle Schritt.
- Die Scoring-Arithmetik. Dafuer gibt es im Repo keinen Code, nur Dokumentation.
- Das Rendering von index.html.

## Unterschiede zwischen lokalem Lauf und Runner

Der lokale Lauf war eine Nachstellung, keine echte GitHub-Action. Was abweicht:

- Lokal Python 3.9.6, auf dem Runner 3.11 aus setup-python. Keines der Skripte nutzt Syntax ab 3.10.
- python war lokal ein Wrapper auf python3, RUNNER_TEMP ein Scratchpad-Verzeichnis. Der Befehlstext ist identisch, die Umgebung nicht.
- Der Pillow-Schritt war lokal ein No-Op (11.3.0 bereits installiert). Auf dem Runner installiert er wirklich.
- Auf dem Mac gibt es kein /usr/share/fonts, beide Banner-Laeufe liefen deshalb ueber den PIL-Default-Pfad. Auf ubuntu-latest sind DejaVu-Fonts vermutlich vorhanden, dann laeuft der TrueType-Zweig mit breiterer Schrift. Deshalb wurden die Texte des sauberen Laufs vorher mit einem echten TrueType-Font gemessen: bei 52px liegt die laengste Titelzeile ("CI Smoke Test") bei 358px Breite gegen ein Budget von 670px, Untertitel, Rolle und Tags bleiben mit noch groesserem Abstand darunter. Auch mit einer deutlich breiteren Schrift bleibt der Lauf damit unter der Safe-Zone-Grenze.

## Zaehne-Test

Drei kuenstliche Brueche, jeweils in einer Kopie des Repos, nie im Repo selbst. Alle drei wurden rot.

Der zentrale: in der Kopie wurde sys.exit(1) aus create_banner.py entfernt, also die Welle-2-Reparatur zurueckgenommen. Der Schritt gab aus: "FEHLER: --strict hat die Safe-Zone-Verletzung nicht gemeldet", Exitcode 1. Aufschlussreich daran ist, dass das Skript die Verletzung weiterhin ausdruckte. Ein Check, der nur die Ausgabe liest, waere gruen geblieben.

Dazu: nur die README-Ueberschrift auf v2.3.0 gesetzt, check_versions.py meldete "Versionsangaben laufen auseinander: v2.2.2, v2.3.0" mit Exitcode 1. Und ein offenes Objektliteral ans Ende von generate_report.js gehaengt, node --check meldete "SyntaxError: Unexpected end of input" mit Exitcode 1.

## Richtiggestellte Aussagen

- Der Report ist seit v2.2.0 DOCX, nicht PDF. README und Landingpage bewarben an acht Stellen einen PDF-Report, eine Karte im Workflow-Abschnitt widersprach sich sogar innerhalb ihrer selbst (Ueberschrift PDF, Text darunter DOCX). Radar-Charts kommen im Report nicht vor, generate_report.js erzeugt kein einziges Diagramm.
- Die dokumentierte Ausfuehrung nannte Dateien, die es nicht gibt: node report.js statt generate_report.js, und dreimal scripts/office/validate.py, das im Repo nicht existiert. An seine Stelle tritt eine Pruefung, die ohne Zusatzskript auskommt.
- Drei Roadmap-Horizonte standen nebeneinander. Die Implementierung reicht bis Monat 6, README und Landingpage versprachen zwoelf. Beide sagen jetzt Monat 6.
- Der Gesamtscore 73 auf der Landingpage war aus den zehn danebenstehenden Werten nicht ableitbar, und die zehn Kategorien kamen in SCORING.md gar nicht vor. Sie sind durch die zehn echten Kategorien mit ihren Gewichten ersetzt, die Zahlen durch die in SCORING.md durchgerechnete Beispielbewertung, deren gewichtete Summe 70,0 ergibt. Der Ring zeigt 70, der stroke-dashoffset wurde von 150 auf 170 mitgezogen. Neue Zahlen wurden nicht erfunden, die nicht belegbare Kennzahl "15+ Seiten" weicht der tatsaechlich angelegten Kapitelzahl.
- Die README hat jetzt einen Abschnitt Grenzen und einen Abschnitt Roadmap, beide aus dem Bestand belegt, und verlinkt die Gewichtstabelle sowie die Benchmark-Tabelle in references/SCORING.md, die bisher nur dort standen.
- Die Version stand an sechs Stellen in drei Varianten und steht jetzt ueberall auf v2.2.2.

## Offen

- Die Nenner-Frage der Engagement-Rate. SCORING.md rechnet gegen Impressions, generate_report.js schaetzt aus der Follower-Zahl. Der geschaetzte Wert liegt systematisch hoeher, die Benchmark-Baender passen also nicht zur berechneten Zahl. Der Widerspruch ist im Abschnitt Grenzen benannt, aufgeloest ist er nicht.
- Der Ausgabepfad des Report-Templates zeigt weiterhin fest auf /mnt/user-data/outputs/.
- requirements.txt und package.json fehlen weiterhin, docx ist nicht gepinnt.
- Die Fehlerbehandlung deckt Rate Limit beziehungsweise LinkedIn-Checkpoint und geaenderte DOM-Struktur noch nicht ab.
- SCORING.md verlangt Radar-Chart und Balkendiagramm, das Template liefert keine Diagramme. Als Grenze dokumentiert, nicht geloest.

index.html blieb unveraendert im Repo-Root, nur inhaltlich korrigiert. Es wurde nichts gepusht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BL7UoPomBp2Luhg89R6fYk

## Wie dieser Branch entstanden ist

Drei Durchgaenge, jeder mit eigener Abnahme:

1. CI anlegen und die im Haerteplan gelisteten Falschaussagen korrigieren.
2. Die Abnahme hat die CI selbst nachgefahren, absichtlich gebrochen, um zu pruefen ob sie Zaehne
   hat, und dabei 8 weitere Aussagen gefunden, die immer noch nicht stimmten. Die wurden im
   zweiten Durchgang korrigiert.
3. Die Nachpruefung des zweiten Durchgangs fand Formulierungen, die beim Korrigieren zu weit
   gingen oder eine neue Ungenauigkeit einfuehrten. Die wurden im dritten Durchgang praezisiert.

Jede Zahl in den geaenderten Texten ist gegen das Repo gemessen, nicht uebernommen.

## Zur CI

Die CI prueft nur, was heute wirklich pruefbar ist. Sie wurde absichtlich gebrochen, um zu
belegen, dass ein realistischer Fehler sie rot macht. Was sie nicht abdeckt, steht in der
Beschreibung der einzelnen Schritte.


---
**Gestapelt.** Dieser PR sitzt auf `fix/welle-2`. GitHub haengt ihn automatisch auf `main` um, sobald der darunterliegende PR gemergt ist. Vorher zeigt der Diff nur die Welle-3-Aenderungen, das ist so gewollt.

Teil von Welle 3 des Haerteplans: CI sichtbar und Claims ehrlich. Jede Aenderung wurde von einem zweiten Durchgang abgenommen, der die CI-Schritte selbst nachgefahren und die CI absichtlich gebrochen hat.
